### PR TITLE
Add simplified Mahjong simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# game
+# Mahjong Game
+
+A lightweight command-line simulator for a four-player Riichi Mahjong round.
+Four automated players draw and discard tiles according to a simple heuristic
+and the engine detects standard winning hands (four melds and a pair) as well as
+Thirteen Orphans.
+
+## Getting started
+
+The project has no runtime dependencies beyond Python 3.10+. To play a round use
+`python main.py`:
+
+```bash
+python main.py
+```
+
+Pass `--quiet` to suppress per-turn logs and `--seed` to reproduce a specific
+shuffle:
+
+```bash
+python main.py --seed 1234 --quiet
+```
+
+The script exits once a player wins or the wall is exhausted.
+
+## Module overview
+
+- `mahjong.tiles` – definitions for tiles and helpers to build/shuffle the wall.
+- `mahjong.player` – basic AI player that evaluates its hand and chooses discards.
+- `mahjong.game` – game loop, hand evaluator and helper dataclasses.
+- `main.py` – CLI for running a simulated round.
+
+Feel free to expand the AI, add scoring or build a graphical interface on top of
+the provided engine.

--- a/mahjong/__init__.py
+++ b/mahjong/__init__.py
@@ -1,0 +1,15 @@
+"""Top-level package for the Mahjong game engine."""
+
+from .tiles import Tile, TileCollection, create_wall, TileNotFound
+from .player import Player
+from .game import MahjongGame, GameResult
+
+__all__ = [
+    "Tile",
+    "TileCollection",
+    "TileNotFound",
+    "create_wall",
+    "Player",
+    "MahjongGame",
+    "GameResult",
+]

--- a/mahjong/game.py
+++ b/mahjong/game.py
@@ -1,0 +1,177 @@
+"""Game loop and hand evaluation for Mahjong."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Iterable, List, Optional, Sequence
+
+from .player import Player
+from .tiles import HONORS, NUMBER_SUITS, Tile, TileCollection, create_wall, format_tiles, tile_sort_key
+
+
+@dataclass
+class GameResult:
+    """Outcome of a played Mahjong round."""
+
+    winner: Optional[Player]
+    winning_tile: Optional[Tile] = None
+    draw: bool = False
+    turns: int = 0
+    logs: List[str] = field(default_factory=list)
+
+    def summary(self) -> str:
+        if self.draw:
+            return "The round ended in an exhaustive draw."
+        assert self.winner is not None
+        return (
+            f"{self.winner.name} wins after {self.turns} turns with hand: "
+            f"{format_tiles(self.winner.hand)} (winning tile {self.winning_tile})"
+        )
+
+
+class MahjongGame:
+    """Simplified four-player Mahjong game simulator."""
+
+    def __init__(self, players: Iterable[Player], seed: int | None = None) -> None:
+        self.players: List[Player] = list(players)
+        if len(self.players) != 4:
+            raise ValueError("The simulator expects exactly four players.")
+        self.seed = seed
+        self.wall: TileCollection = TileCollection()
+        self.discards: List[Tile] = []
+        self.turn = 0
+
+    def setup_round(self) -> None:
+        self.wall = create_wall(self.seed)
+        self.discards = []
+        self.turn = 0
+        for player in self.players:
+            player.hand.clear()
+            player.discards.clear()
+        # Deal 13 tiles to each player in order
+        for player in self.players:
+            starting_hand = [self.wall.draw() for _ in range(13)]
+            player.take_initial_hand(starting_hand)
+
+    def play_round(self, max_turns: int | None = None, log: bool = True) -> GameResult:
+        self.setup_round()
+        logs: List[str] = []
+        player_index = 0
+        max_turns = max_turns or len(self.wall)
+
+        while len(self.wall) > 0 and self.turn < max_turns:
+            player = self.players[player_index]
+            drawn_tile = self.wall.draw()
+            player.draw(drawn_tile)
+            self.turn += 1
+            if log:
+                logs.append(f"Turn {self.turn}: {player.name} draws {drawn_tile} -> {player.describe_hand()}")
+
+            if is_winning_hand(player.hand):
+                result = GameResult(
+                    winner=player,
+                    winning_tile=drawn_tile,
+                    draw=False,
+                    turns=self.turn,
+                    logs=logs,
+                )
+                if log:
+                    logs.append(f"{player.name} wins!")
+                return result
+
+            discard = player.choose_discard()
+            self.discards.append(discard)
+            if log:
+                logs.append(f"{player.name} discards {discard}. Discards: {player.describe_discards()}")
+
+            player_index = (player_index + 1) % len(self.players)
+
+        return GameResult(winner=None, draw=True, turns=self.turn, logs=logs)
+
+
+def is_winning_hand(hand: Sequence[Tile]) -> bool:
+    """Return ``True`` if *hand* forms a winning hand under basic rules."""
+
+    if len(hand) != 14:
+        return False
+
+    counts = Counter(hand)
+    if any(count > 4 for count in counts.values()):
+        return False
+
+    if _is_thirteen_orphans(counts):
+        return True
+
+    return _standard_hand_checker(counts)
+
+
+def _standard_hand_checker(counts: Counter[Tile]) -> bool:
+    # Try every possible pair and see if the rest of the tiles form melds.
+    for tile, count in list(counts.items()):
+        if count >= 2:
+            counts[tile] -= 2
+            if counts[tile] == 0:
+                del counts[tile]
+            if _can_form_melds(counts):
+                counts[tile] = counts.get(tile, 0) + 2
+                return True
+            counts[tile] = counts.get(tile, 0) + 2
+    return False
+
+
+def _can_form_melds(counts: Counter[Tile]) -> bool:
+    if not counts:
+        return True
+
+    tile = min(counts, key=tile_sort_key)
+    remaining = counts[tile]
+
+    if remaining >= 3:
+        counts[tile] -= 3
+        if counts[tile] == 0:
+            del counts[tile]
+        if _can_form_melds(counts):
+            counts[tile] = counts.get(tile, 0) + 3
+            return True
+        counts[tile] = counts.get(tile, 0) + 3
+
+    if tile.suit in NUMBER_SUITS:
+        value = int(tile.value)
+        if value <= 7:
+            sequence_tiles = [Tile(tile.suit, str(value + i)) for i in range(3)]
+        else:
+            sequence_tiles = []
+        if sequence_tiles and all(counts.get(seq_tile, 0) > 0 for seq_tile in sequence_tiles):
+            for seq_tile in sequence_tiles:
+                counts[seq_tile] -= 1
+                if counts[seq_tile] == 0:
+                    del counts[seq_tile]
+            if _can_form_melds(counts):
+                for seq_tile in sequence_tiles:
+                    counts[seq_tile] = counts.get(seq_tile, 0) + 1
+                return True
+            for seq_tile in sequence_tiles:
+                counts[seq_tile] = counts.get(seq_tile, 0) + 1
+
+    return False
+
+
+def _is_thirteen_orphans(counts: Counter[Tile]) -> bool:
+    required_terminals = {
+        Tile("man", "1"),
+        Tile("man", "9"),
+        Tile("pin", "1"),
+        Tile("pin", "9"),
+        Tile("sou", "1"),
+        Tile("sou", "9"),
+    }
+    required_honors = {Tile("honor", honor) for honor in HONORS}
+    required_tiles = required_terminals | required_honors
+
+    unique_tiles = {tile for tile, count in counts.items() if count > 0}
+    if not required_tiles.issubset(unique_tiles):
+        return False
+
+    pair_found = any(count >= 2 for tile, count in counts.items() if tile in required_tiles)
+    return pair_found and sum(counts.values()) == 14

--- a/mahjong/player.py
+++ b/mahjong/player.py
@@ -1,0 +1,73 @@
+"""Player implementation for the Mahjong game."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Iterable, List
+
+from .tiles import Tile, format_tiles, tile_sort_key
+
+
+@dataclass
+class Player:
+    """Represents a Mahjong player with a very small AI.
+
+    The AI is intentionally lightweight—it merely evaluates the suitability of
+    each tile in the hand and discards the tile that contributes the least to a
+    potential winning shape. The heuristic is deterministic which makes the
+    simulation repeatable and aids debugging.
+    """
+
+    name: str
+    hand: List[Tile] = field(default_factory=list)
+    discards: List[Tile] = field(default_factory=list)
+
+    def draw(self, tile: Tile) -> None:
+        self.hand.append(tile)
+        self.sort_hand()
+
+    def sort_hand(self) -> None:
+        self.hand.sort(key=tile_sort_key)
+
+    def take_initial_hand(self, tiles: Iterable[Tile]) -> None:
+        self.hand = list(tiles)
+        self.sort_hand()
+
+    def choose_discard(self) -> Tile:
+        if not self.hand:
+            raise ValueError("Cannot discard from an empty hand")
+
+        counts = Counter(self.hand)
+        evaluated = sorted(self.hand, key=lambda tile: (self._tile_score(tile, counts), tile_sort_key(tile)))
+        tile = evaluated[0]
+        self.hand.remove(tile)
+        self.discards.append(tile)
+        return tile
+
+    def _tile_score(self, tile: Tile, counts: Counter[Tile]) -> int:
+        """Return a heuristic score for *tile*.
+
+        Lower scores indicate worse tiles (i.e. more likely to be discarded).
+        The scoring favours triplets, sequences and honour tiles with duplicates.
+        """
+
+        score = counts[tile] * 3
+        if tile.is_honor:
+            return score
+
+        value = int(tile.value)
+        neighbours = 0
+        for offset in (-2, -1, 1, 2):
+            candidate_value = value + offset
+            if 1 <= candidate_value <= 9:
+                candidate = Tile(tile.suit, str(candidate_value))
+                if counts[candidate]:
+                    neighbours += 1
+        return score + neighbours
+
+    def describe_hand(self) -> str:
+        return format_tiles(self.hand)
+
+    def describe_discards(self) -> str:
+        return format_tiles(self.discards)

--- a/mahjong/tiles.py
+++ b/mahjong/tiles.py
@@ -1,0 +1,144 @@
+"""Tile definitions and helpers for a simplified Mahjong ruleset."""
+
+from __future__ import annotations
+
+import random
+from collections import Counter
+from dataclasses import dataclass
+from typing import Iterable, Iterator, List, Sequence
+
+NUMBER_SUITS = ("man", "pin", "sou")
+HONORS = ("east", "south", "west", "north", "white", "green", "red")
+
+
+class TileNotFound(LookupError):
+    """Raised when attempting to remove a tile that is not present."""
+
+
+@dataclass(frozen=True, order=True)
+class Tile:
+    """Representation of a Mahjong tile.
+
+    The implementation is intentionally lightweight: only the ``suit`` and
+    ``value`` attributes are stored. For suited tiles the value is a string in
+    ``{"1", ..., "9"}``; for honors the value is one of :data:`HONORS`.
+    """
+
+    suit: str
+    value: str
+
+    def __post_init__(self) -> None:  # pragma: no cover - trivial validation
+        if self.suit not in NUMBER_SUITS + ("honor",):
+            raise ValueError(f"Unknown suit: {self.suit!r}")
+        if self.suit == "honor":
+            if self.value not in HONORS:
+                raise ValueError(f"Unknown honor tile: {self.value!r}")
+        else:
+            if self.value not in {str(i) for i in range(1, 10)}:
+                raise ValueError(f"Invalid tile value for {self.suit}: {self.value!r}")
+
+    @property
+    def is_honor(self) -> bool:
+        return self.suit == "honor"
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.suit != "honor" and self.value in {"1", "9"}
+
+    def __str__(self) -> str:  # pragma: no cover - presentation
+        return f"{self.value}{self.suit[0]}" if not self.is_honor else self.value[0].upper()
+
+
+_TILE_ORDER: List[Tile] = [
+    Tile(suit, str(value))
+    for suit in NUMBER_SUITS
+    for value in range(1, 10)
+] + [Tile("honor", honor) for honor in HONORS]
+_TILE_INDEX = {tile: index for index, tile in enumerate(_TILE_ORDER)}
+
+
+class TileCollection:
+    """Mutable container for Mahjong tiles.
+
+    The collection keeps a deterministic order (useful for pretty printing) but
+    also exposes helpers to draw tiles from the "top" much like a real wall.
+    """
+
+    def __init__(self, tiles: Iterable[Tile] | None = None) -> None:
+        self._tiles: List[Tile] = list(tiles or [])
+
+    def __len__(self) -> int:
+        return len(self._tiles)
+
+    def __iter__(self) -> Iterator[Tile]:
+        return iter(self._tiles)
+
+    def append(self, tile: Tile) -> None:
+        self._tiles.append(tile)
+
+    def extend(self, tiles: Iterable[Tile]) -> None:
+        self._tiles.extend(tiles)
+
+    def pop(self, index: int = -1) -> Tile:
+        if not self._tiles:
+            raise IndexError("Cannot pop from an empty TileCollection")
+        return self._tiles.pop(index)
+
+    def draw(self) -> Tile:
+        """Draw a tile from the end of the collection."""
+
+        return self.pop()
+
+    def remove(self, tile: Tile) -> None:
+        """Remove a tile from the collection.
+
+        Raises:
+            TileNotFound: If the tile is not present.
+        """
+
+        try:
+            self._tiles.remove(tile)
+        except ValueError as exc:  # pragma: no cover - thin wrapper
+            raise TileNotFound(str(exc)) from exc
+
+    def sort(self) -> None:
+        self._tiles.sort(key=_TILE_INDEX.get)
+
+    def counts(self) -> Counter[Tile]:
+        return Counter(self._tiles)
+
+    def copy(self) -> "TileCollection":
+        return TileCollection(self._tiles)
+
+    def __repr__(self) -> str:  # pragma: no cover - presentation
+        return f"TileCollection({self._tiles!r})"
+
+
+def create_wall(seed: int | None = None) -> TileCollection:
+    """Return a shuffled wall containing 136 tiles.
+
+    The :class:`TileCollection` behaves similarly to the live wall in a Mahjong
+    game: callers can repeatedly call :meth:`TileCollection.draw` to simulate
+    drawing tiles. The optional *seed* argument makes the shuffle deterministic
+    which is invaluable for unit tests and debugging sessions.
+    """
+
+    rng = random.Random(seed)
+    tiles: List[Tile] = []
+    for tile in _TILE_ORDER:
+        tiles.extend([tile] * 4)
+    rng.shuffle(tiles)
+    return TileCollection(tiles)
+
+
+def tile_sort_key(tile: Tile) -> int:
+    """Return a deterministic sort key for *tile*."""
+
+    return _TILE_INDEX[tile]
+
+
+def format_tiles(tiles: Sequence[Tile]) -> str:
+    """Return a compact human readable representation of *tiles*."""
+
+    sorted_tiles = sorted(tiles, key=tile_sort_key)
+    return " ".join(str(tile) for tile in sorted_tiles)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,38 @@
+"""Command line entry point for the Mahjong simulator."""
+
+from __future__ import annotations
+
+import argparse
+from typing import List
+
+from mahjong import MahjongGame, Player
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Simulate a round of Riichi Mahjong with simple AI players.")
+    parser.add_argument("--seed", type=int, default=None, help="Optional seed for deterministic shuffles.")
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress the per-turn log output and print only the final result.",
+    )
+    return parser
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    players = [Player(name) for name in ("East", "South", "West", "North")]
+    game = MahjongGame(players, seed=args.seed)
+    result = game.play_round(log=not args.quiet)
+
+    if not args.quiet:
+        for line in result.logs:
+            print(line)
+    print(result.summary())
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI glue
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- implement tile, player and game modules for a simplified Riichi Mahjong round
- add a command line interface to run automated matches
- document usage and ignore Python bytecode artifacts

## Testing
- python main.py --seed 1 --quiet

------
https://chatgpt.com/codex/tasks/task_e_6905bd08fe008321886b9bd9dc0ad2af