### PR TITLE
Add browser prototype for Mahjong round setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ python main.py --seed 1234 --quiet
 
 The script exits once a player wins or the wall is exhausted.
 
+## Browser prototype
+
+An experimental browser front-end that mirrors the Python engine is available in
+`index.html`. Open the file directly in a browser to try the lightweight UI. It
+currently supports the following features:
+
+- 136-tile wall with Fisher–Yates shuffle
+- Automatic distribution of starting hands (dealer receives 14 tiles)
+- Dora indicator display and wall counter
+- Manual draws and discards for the player at the bottom of the table (click a
+  tile to discard)
+
+Further features such as calls (チー・ポン・カン), win detection and scoring are
+planned but not yet implemented.
+
 ## Module overview
 
 - `mahjong.tiles` – definitions for tiles and helpers to build/shuffle the wall.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Riichi Mahjong Simulator</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="app-header">
+    <h1>Riichi Mahjong Simulator</h1>
+    <p class="subtitle">軽量ブラウザ版 - 最低限の局進行をテストできます</p>
+  </header>
+
+  <main class="table" aria-live="polite">
+    <section class="table-info">
+      <div>山残り: <span id="wall-count">0</span></div>
+      <div>ドラ表示牌: <span id="dora-indicator">未設定</span></div>
+    </section>
+
+    <section class="players">
+      <div class="player player-top" data-player="south">
+        <h2>南家</h2>
+        <div class="hand" data-role="hand"></div>
+        <div class="river" data-role="river"></div>
+      </div>
+
+      <div class="player player-left" data-player="east">
+        <h2>東家 (CPU)</h2>
+        <div class="hand" data-role="hand"></div>
+        <div class="river" data-role="river"></div>
+      </div>
+
+      <div class="center-controls">
+        <button id="start-round" type="button">配牌スタート</button>
+        <button id="draw-tile" type="button" disabled>ツモ</button>
+        <p class="hint">※ 下段の自分の手牌をクリックすると捨てられます</p>
+      </div>
+
+      <div class="player player-right" data-player="west">
+        <h2>西家 (CPU)</h2>
+        <div class="hand" data-role="hand"></div>
+        <div class="river" data-role="river"></div>
+      </div>
+
+      <div class="player player-bottom" data-player="north">
+        <h2>北家 (あなた)</h2>
+        <div class="hand" data-role="hand" aria-label="あなたの手牌"></div>
+        <div class="river" data-role="river" aria-label="あなたの捨て牌"></div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="app-footer">
+    <small>WIP: チー・ポン・カンや役判定は今後追加予定です。</small>
+  </footer>
+
+  <script src="main.js" type="module"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,252 @@
+const NUMBER_SUITS = [
+  { key: "man", label: "萬子", values: ["1", "2", "3", "4", "5", "6", "7", "8", "9"] },
+  { key: "pin", label: "筒子", values: ["1", "2", "3", "4", "5", "6", "7", "8", "9"] },
+  { key: "sou", label: "索子", values: ["1", "2", "3", "4", "5", "6", "7", "8", "9"] },
+];
+
+const HONORS = [
+  { key: "east", label: "東" },
+  { key: "south", label: "南" },
+  { key: "west", label: "西" },
+  { key: "north", label: "北" },
+  { key: "white", label: "白" },
+  { key: "green", label: "發" },
+  { key: "red", label: "中" },
+];
+
+const PLAYER_ORDER = ["south", "east", "west", "north"];
+const PLAYER_NAMES = {
+  south: "南家",
+  east: "東家",
+  west: "西家",
+  north: "北家",
+};
+
+const state = {
+  wall: [],
+  hands: {
+    south: [],
+    east: [],
+    west: [],
+    north: [],
+  },
+  rivers: {
+    south: [],
+    east: [],
+    west: [],
+    north: [],
+  },
+  doraIndicator: null,
+  dealerIndex: 0,
+  currentTurn: 0,
+};
+
+function createTile({ suit, value, copy }) {
+  const isHonor = suit === "honor";
+  const identifier = `${suit}-${value}-${copy}`;
+  return {
+    id: identifier,
+    suit,
+    value,
+    isHonor,
+    text: formatTileText(suit, value),
+  };
+}
+
+function formatTileText(suit, value) {
+  if (suit === "honor") {
+    const honor = HONORS.find((item) => item.key === value);
+    return honor ? honor.label : value;
+  }
+  const suitLabel = NUMBER_SUITS.find((item) => item.key === suit);
+  const suffix = suitLabel ? suitLabel.label.charAt(0) : suit[0];
+  return `${value}${suffix}`;
+}
+
+function buildWall() {
+  const tiles = [];
+  NUMBER_SUITS.forEach((suit) => {
+    suit.values.forEach((value) => {
+      for (let copy = 0; copy < 4; copy += 1) {
+        tiles.push(createTile({ suit: suit.key, value, copy }));
+      }
+    });
+  });
+  HONORS.forEach((honor) => {
+    for (let copy = 0; copy < 4; copy += 1) {
+      tiles.push(createTile({ suit: "honor", value: honor.key, copy }));
+    }
+  });
+  return tiles;
+}
+
+function shuffle(array) {
+  for (let i = array.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+}
+
+function resetState() {
+  state.wall = shuffle(buildWall());
+  state.hands = {
+    south: [],
+    east: [],
+    west: [],
+    north: [],
+  };
+  state.rivers = {
+    south: [],
+    east: [],
+    west: [],
+    north: [],
+  };
+  state.currentTurn = 0;
+  state.dealerIndex = 0;
+  state.doraIndicator = null;
+}
+
+function drawTile(playerKey) {
+  if (state.wall.length === 0) {
+    return null;
+  }
+  const tile = state.wall.pop();
+  state.hands[playerKey].push(tile);
+  sortHand(playerKey);
+  updateWallCount();
+  return tile;
+}
+
+function sortHand(playerKey) {
+  state.hands[playerKey].sort((a, b) => {
+    if (a.suit === b.suit) {
+      return a.value.localeCompare(b.value);
+    }
+    if (a.suit === "honor") return 1;
+    if (b.suit === "honor") return -1;
+    return a.suit.localeCompare(b.suit);
+  });
+}
+
+function dealInitialHands() {
+  PLAYER_ORDER.forEach((player) => {
+    state.hands[player] = [];
+  });
+  for (let round = 0; round < 3; round += 1) {
+    PLAYER_ORDER.forEach((player) => {
+      for (let i = 0; i < 4; i += 1) {
+        drawTile(player);
+      }
+    });
+  }
+  PLAYER_ORDER.forEach((player) => drawTile(player));
+  const dealerKey = PLAYER_ORDER[state.dealerIndex];
+  drawTile(dealerKey);
+  // Dora indicator = last tile in wall (just peek)
+  state.doraIndicator = state.wall[state.wall.length - 1] || null;
+}
+
+function discardTile(playerKey, tileId) {
+  const hand = state.hands[playerKey];
+  const tileIndex = hand.findIndex((tile) => tile.id === tileId);
+  if (tileIndex === -1) return;
+  const [tile] = hand.splice(tileIndex, 1);
+  state.rivers[playerKey].push(tile);
+  render();
+}
+
+function updateWallCount() {
+  const wallCount = document.querySelector("#wall-count");
+  if (wallCount) {
+    wallCount.textContent = state.wall.length.toString();
+  }
+}
+
+function updateDoraIndicator() {
+  const doraNode = document.querySelector("#dora-indicator");
+  if (!doraNode) return;
+  doraNode.textContent = state.doraIndicator ? state.doraIndicator.text : "未設定";
+}
+
+function renderHands() {
+  document.querySelectorAll(".player").forEach((playerEl) => {
+    const playerKey = playerEl.dataset.player;
+    const handContainer = playerEl.querySelector('[data-role="hand"]');
+    const riverContainer = playerEl.querySelector('[data-role="river"]');
+    if (!playerKey || !handContainer || !riverContainer) {
+      return;
+    }
+
+    handContainer.innerHTML = "";
+    riverContainer.innerHTML = "";
+
+    state.hands[playerKey].forEach((tile) => {
+      const button = document.createElement("button");
+      button.className = "tile";
+      button.type = "button";
+      button.textContent = tile.text;
+      button.dataset.tileId = tile.id;
+      if (playerKey === "north") {
+        button.addEventListener("click", () => {
+          discardTile(playerKey, tile.id);
+        });
+      }
+      handContainer.appendChild(button);
+    });
+
+    state.rivers[playerKey].forEach((tile) => {
+      const span = document.createElement("span");
+      span.className = "tile";
+      span.textContent = tile.text;
+      riverContainer.appendChild(span);
+    });
+  });
+}
+
+function render() {
+  updateWallCount();
+  updateDoraIndicator();
+  renderHands();
+}
+
+function startRound() {
+  resetState();
+  dealInitialHands();
+  render();
+  state.currentTurn = 0;
+  const drawButton = document.querySelector("#draw-tile");
+  if (drawButton) {
+    drawButton.disabled = false;
+  }
+}
+
+function handleDraw() {
+  const tile = drawTile("north");
+  if (!tile) {
+    return;
+  }
+  render();
+}
+
+function bindEvents() {
+  const startButton = document.querySelector("#start-round");
+  const drawButton = document.querySelector("#draw-tile");
+  if (startButton) {
+    startButton.addEventListener("click", () => {
+      startRound();
+    });
+  }
+  if (drawButton) {
+    drawButton.addEventListener("click", () => {
+      handleDraw();
+    });
+  }
+}
+
+function init() {
+  bindEvents();
+  render();
+}
+
+document.addEventListener("DOMContentLoaded", init);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,184 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Noto Sans JP", system-ui, sans-serif;
+  background-color: #0b1623;
+  color: #f2f5f7;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header,
+.app-footer {
+  padding: 1rem;
+  background: linear-gradient(135deg, #17304a, #0b1623 70%);
+  text-align: center;
+}
+
+.subtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+  color: #a1c7ff;
+}
+
+.app-footer {
+  font-size: 0.8rem;
+  color: #8aa0b8;
+}
+
+.table {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.5rem 1rem 2rem;
+}
+
+.table-info {
+  display: flex;
+  gap: 1rem;
+  font-size: 1rem;
+  background: rgba(12, 24, 36, 0.8);
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+}
+
+.players {
+  width: min(960px, 95vw);
+  display: grid;
+  grid-template-areas:
+    "top top top"
+    "left center right"
+    "bottom bottom bottom";
+  gap: 1rem;
+}
+
+.player {
+  background: rgba(16, 32, 48, 0.85);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.player h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.player-top {
+  grid-area: top;
+}
+
+.player-left {
+  grid-area: left;
+}
+
+.player-right {
+  grid-area: right;
+}
+
+.player-bottom {
+  grid-area: bottom;
+}
+
+.center-controls {
+  grid-area: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 1rem;
+  background: rgba(12, 24, 36, 0.7);
+  border-radius: 0.75rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.center-controls button {
+  min-width: 140px;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #32b68e, #218866);
+  color: #fff;
+  font-size: 1rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.center-controls button:disabled {
+  cursor: not-allowed;
+  background: #3a4a5d;
+  color: #c9d5e2;
+}
+
+.center-controls button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(33, 136, 102, 0.45);
+}
+
+.center-controls .hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #b5c9dd;
+  text-align: center;
+}
+
+.hand,
+.river {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  min-height: 40px;
+}
+
+.tile {
+  padding: 0.35rem 0.6rem;
+  border-radius: 0.5rem;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: inherit;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: default;
+  transition: transform 0.1s ease, background 0.2s ease;
+}
+
+.player-bottom .tile {
+  cursor: pointer;
+}
+
+.player-bottom .tile:hover {
+  transform: translateY(-3px);
+  background: rgba(255, 255, 255, 0.2);
+}
+
+@media (max-width: 768px) {
+  .players {
+    grid-template-areas:
+      "top"
+      "center"
+      "left"
+      "right"
+      "bottom";
+  }
+
+  .player {
+    align-items: center;
+  }
+
+  .hand,
+  .river {
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone browser prototype with index.html, style.css, and main.js
- implement tile data structures, Fisher–Yates shuffle, and initial dealing logic in the browser
- expose minimal UI for wall count, dora indicator, manual draws, and discards
- document the prototype in the README

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_6905bf70af408321892dc83bef3c353c