### PR TITLE
Implement browser mahjong round flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,11 @@
         <div class="river" data-role="river" aria-label="あなたの捨て牌"></div>
       </div>
     </section>
+
+    <section class="log-panel" aria-live="polite" aria-label="進行ログ">
+      <h2>進行ログ</h2>
+      <ol id="log" class="log-list"></ol>
+    </section>
   </main>
 
   <footer class="app-footer">

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 :root {
   color-scheme: light dark;
   font-family: "Noto Sans JP", system-ui, sans-serif;
-  background-color: #0b1623;
+  background-color: #0f2a21;
   color: #f2f5f7;
 }
 
@@ -10,12 +10,13 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  background: radial-gradient(circle at 50% 20%, #2c7d55, #0f2a21 70%);
 }
 
 .app-header,
 .app-footer {
   padding: 1rem;
-  background: linear-gradient(135deg, #17304a, #0b1623 70%);
+  background: linear-gradient(135deg, rgba(17, 71, 52, 0.9), rgba(10, 43, 33, 0.95) 70%);
   text-align: center;
 }
 
@@ -43,10 +44,10 @@ body {
   display: flex;
   gap: 1rem;
   font-size: 1rem;
-  background: rgba(12, 24, 36, 0.8);
+  background: rgba(7, 38, 30, 0.75);
   padding: 0.5rem 1rem;
   border-radius: 0.5rem;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.35);
 }
 
 .players {
@@ -60,10 +61,10 @@ body {
 }
 
 .player {
-  background: rgba(16, 32, 48, 0.85);
+  background: rgba(11, 56, 42, 0.85);
   border-radius: 0.75rem;
   padding: 0.75rem;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08), 0 12px 24px rgba(0, 0, 0, 0.25);
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -98,7 +99,7 @@ body {
   justify-content: center;
   gap: 0.75rem;
   padding: 1rem;
-  background: rgba(12, 24, 36, 0.7);
+  background: rgba(7, 38, 30, 0.7);
   border-radius: 0.75rem;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
 }
@@ -108,7 +109,7 @@ body {
   padding: 0.5rem 1rem;
   border-radius: 999px;
   border: none;
-  background: linear-gradient(135deg, #32b68e, #218866);
+  background: linear-gradient(135deg, #3ac78f, #22865e);
   color: #fff;
   font-size: 1rem;
   font-weight: bold;
@@ -124,7 +125,7 @@ body {
 
 .center-controls button:not(:disabled):hover {
   transform: translateY(-1px);
-  box-shadow: 0 6px 16px rgba(33, 136, 102, 0.45);
+  box-shadow: 0 6px 16px rgba(49, 163, 112, 0.45);
 }
 
 .center-controls .hint {
@@ -145,8 +146,8 @@ body {
 .tile {
   padding: 0.35rem 0.6rem;
   border-radius: 0.5rem;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.25);
   color: inherit;
   font-size: 0.95rem;
   font-weight: 600;
@@ -160,7 +161,50 @@ body {
 
 .player-bottom .tile:hover {
   transform: translateY(-3px);
-  background: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.player-bottom .tile:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  transform: none;
+}
+
+.log-panel {
+  width: min(960px, 95vw);
+  background: rgba(7, 38, 30, 0.7);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem 1rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05), 0 10px 18px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.log-panel h2 {
+  margin: 0;
+  font-size: 1rem;
+  color: #bfe8cd;
+}
+
+.log-list {
+  list-style: decimal;
+  padding-left: 1.2rem;
+  margin: 0;
+  max-height: 180px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  color: #e6f5ec;
+}
+
+.log-list li {
+  background: rgba(22, 78, 61, 0.55);
+  border-radius: 0.5rem;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 0.9rem;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- add a visible log panel to the browser UI and automatically start a round on load
- restyle the table with a green felt-inspired palette and log panel styling
- implement turn handling, CPU draws/discards, and player draw/discard phases with logging in main.js

## Testing
- node --check main.js

------
https://chatgpt.com/codex/tasks/task_e_6905c3fb9e14832191b469e9aaf04f7d