### PR TITLE
Add standalone Tetris web client

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,29 @@ The script exits once a player wins or the wall is exhausted.
 
 ## Browser prototype
 
-An experimental browser front-end that mirrors the Python engine is available in
-`index.html`. Open the file directly in a browser to try the lightweight UI. It
-currently supports the following features:
+The repository also ships with a standalone HTML5版テトリス. Open `index.html`
+in a modern browser to start playing instantly. The implementation relies solely
+on HTML, CSS and vanilla JavaScript—no build step or external libraries.
 
-- 136-tile wall with Fisher–Yates shuffle
-- Automatic distribution of starting hands (dealer receives 14 tiles)
-- Dora indicator display and wall counter
-- Manual draws and discards for the player at the bottom of the table (click a
-  tile to discard)
+### 主な特徴
 
-Further features such as calls (チー・ポン・カン), win detection and scoring are
-planned but not yet implemented.
+- 10×20のプレイフィールドと7種類のテトリミノをサポート
+- 7バッグ方式でテトリミノをランダム生成
+- ソフトドロップ／ハードドロップ、回転、左右移動に対応
+- ライン消去でスコア加算、一定行数ごとにレベルアップ＆落下加速
+- 次のミノ表示、スコア・ライン・レベル表示、ゲームオーバー判定
+
+### 操作方法
+
+| キー | 動作 |
+| --- | --- |
+| ← / → | 左右に1マス移動 |
+| ↑ | 右回転 |
+| ↓ | ソフトドロップ |
+| スペース | ハードドロップ |
+| R | ゲームをリスタート |
+
+行消去数に応じてスコアが加算され、10ラインごとにレベルが上がって落下速度が速くなります。
 
 ## Module overview
 

--- a/index.html
+++ b/index.html
@@ -3,62 +3,73 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Riichi Mahjong Simulator</title>
+  <title>Classic Tetris</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <header class="app-header">
-    <h1>Riichi Mahjong Simulator</h1>
-    <p class="subtitle">軽量ブラウザ版 - 最低限の局進行をテストできます</p>
-  </header>
+  <div class="app-shell">
+    <header class="app-header">
+      <h1>Classic Tetris</h1>
+      <p class="subtitle">HTML + CSS + JavaScript だけで遊べるシンプルなテトリス</p>
+    </header>
 
-  <main class="table" aria-live="polite">
-    <section class="table-info">
-      <div>山残り: <span id="wall-count">0</span></div>
-      <div>ドラ表示牌: <span id="dora-indicator">未設定</span></div>
-    </section>
+    <main class="game-container" aria-live="polite">
+      <section class="hud" aria-label="ゲーム情報">
+        <div class="hud-panel">
+          <h2>スコア</h2>
+          <p id="score" class="hud-value">0</p>
+        </div>
+        <div class="hud-panel">
+          <h2>レベル</h2>
+          <p id="level" class="hud-value">1</p>
+        </div>
+        <div class="hud-panel">
+          <h2>消去ライン</h2>
+          <p id="lines" class="hud-value">0</p>
+        </div>
+        <div class="hud-panel hud-panel--next">
+          <h2>Next</h2>
+          <canvas id="next" width="120" height="120" aria-label="次のテトリミノ表示"></canvas>
+        </div>
+        <p id="status" class="status" data-status>READY</p>
+        <button id="restart" type="button" class="primary-button" aria-label="ゲームをリスタート">リスタート (R)</button>
+      </section>
 
-    <section class="players">
-      <div class="player player-top" data-player="south">
-        <h2>南家</h2>
-        <div class="hand" data-role="hand"></div>
-        <div class="river" data-role="river"></div>
-      </div>
+      <section class="playfield" aria-label="プレイフィールド">
+        <canvas id="board" width="320" height="640"></canvas>
+      </section>
 
-      <div class="player player-left" data-player="east">
-        <h2>東家 (CPU)</h2>
-        <div class="hand" data-role="hand"></div>
-        <div class="river" data-role="river"></div>
-      </div>
+      <section class="help" aria-label="操作説明">
+        <h2>操作</h2>
+        <dl>
+          <div>
+            <dt>← / →</dt>
+            <dd>左右に移動</dd>
+          </div>
+          <div>
+            <dt>↑</dt>
+            <dd>右回転</dd>
+          </div>
+          <div>
+            <dt>↓</dt>
+            <dd>ソフトドロップ</dd>
+          </div>
+          <div>
+            <dt>スペース</dt>
+            <dd>ハードドロップ</dd>
+          </div>
+          <div>
+            <dt>R</dt>
+            <dd>リスタート</dd>
+          </div>
+        </dl>
+      </section>
+    </main>
 
-      <div class="center-controls">
-        <button id="start-round" type="button">配牌スタート</button>
-        <button id="draw-tile" type="button" disabled>ツモ</button>
-        <p class="hint">※ 下段の自分の手牌をクリックすると捨てられます</p>
-      </div>
-
-      <div class="player player-right" data-player="west">
-        <h2>西家 (CPU)</h2>
-        <div class="hand" data-role="hand"></div>
-        <div class="river" data-role="river"></div>
-      </div>
-
-      <div class="player player-bottom" data-player="north">
-        <h2>北家 (あなた)</h2>
-        <div class="hand" data-role="hand" aria-label="あなたの手牌"></div>
-        <div class="river" data-role="river" aria-label="あなたの捨て牌"></div>
-      </div>
-    </section>
-
-    <section class="log-panel" aria-live="polite" aria-label="進行ログ">
-      <h2>進行ログ</h2>
-      <ol id="log" class="log-list"></ol>
-    </section>
-  </main>
-
-  <footer class="app-footer">
-    <small>WIP: チー・ポン・カンや役判定は今後追加予定です。</small>
-  </footer>
+    <footer class="app-footer">
+      <small>ラインを揃えてスコアを稼ごう！ レベルが上がると落下速度もアップします。</small>
+    </footer>
+  </div>
 
   <script src="main.js" type="module"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -1,228 +1,219 @@
 :root {
-  color-scheme: light dark;
-  font-family: "Noto Sans JP", system-ui, sans-serif;
-  background-color: #0f2a21;
-  color: #f2f5f7;
+  --bg-color: #0f172a;
+  --panel-color: #1e293b;
+  --accent-color: #38bdf8;
+  --text-color: #e2e8f0;
+  --muted-color: #94a3b8;
+  --danger-color: #f87171;
+  font-family: "Segoe UI", "Hiragino Sans", "Noto Sans JP", system-ui, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
+  background: radial-gradient(circle at top, #1d4ed8 0%, var(--bg-color) 55%);
+  color: var(--text-color);
   display: flex;
-  flex-direction: column;
-  background: radial-gradient(circle at 50% 20%, #2c7d55, #0f2a21 70%);
+  justify-content: center;
+  align-items: stretch;
+  padding: 24px 16px 40px;
 }
 
-.app-header,
-.app-footer {
-  padding: 1rem;
-  background: linear-gradient(135deg, rgba(17, 71, 52, 0.9), rgba(10, 43, 33, 0.95) 70%);
+.app-shell {
+  width: min(1100px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.app-header {
   text-align: center;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 3rem);
+  letter-spacing: 0.08em;
 }
 
 .subtitle {
-  margin: 0.25rem 0 0;
-  font-size: 0.9rem;
-  color: #a1c7ff;
+  margin: 8px 0 0;
+  font-size: 0.95rem;
+  color: var(--muted-color);
+}
+
+.game-container {
+  display: grid;
+  grid-template-columns: 220px 1fr 220px;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.hud,
+.help {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 16px;
+  padding: 20px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.45);
+}
+
+.hud-panel h2,
+.help h2 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.04em;
+}
+
+.hud-value {
+  margin: 4px 0 0;
+  font-size: 1.8rem;
+  font-weight: 600;
+}
+
+.hud-panel--next {
+  align-items: center;
+}
+
+#next {
+  margin-top: 8px;
+  background: #0f172a;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.status {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.12em;
+  text-align: center;
+  color: var(--accent-color);
+}
+
+.status[data-state="gameover"] {
+  color: var(--danger-color);
+}
+
+.primary-button {
+  border: none;
+  border-radius: 999px;
+  padding: 10px 18px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  background: linear-gradient(135deg, #0ea5e9, #22d3ee);
+  color: #0f172a;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.primary-button:hover,
+.primary-button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(14, 165, 233, 0.3);
+}
+
+.primary-button:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.playfield {
+  background: rgba(15, 23, 42, 0.4);
+  border-radius: 24px;
+  padding: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1), 0 20px 45px rgba(15, 23, 42, 0.55);
+}
+
+#board {
+  background: #0b1120;
+  border-radius: 12px;
+  border: 2px solid rgba(148, 163, 184, 0.35);
+  box-shadow: inset 0 0 18px rgba(14, 165, 233, 0.25);
+}
+
+.help dl {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  row-gap: 10px;
+  column-gap: 12px;
+  margin: 0;
+}
+
+.help dt {
+  font-weight: 600;
+  color: var(--accent-color);
+}
+
+.help dd {
+  margin: 0;
+  color: var(--muted-color);
 }
 
 .app-footer {
-  font-size: 0.8rem;
-  color: #8aa0b8;
-}
-
-.table {
-  flex: 1 1 auto;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1rem;
-  padding: 1.5rem 1rem 2rem;
-}
-
-.table-info {
-  display: flex;
-  gap: 1rem;
-  font-size: 1rem;
-  background: rgba(7, 38, 30, 0.75);
-  padding: 0.5rem 1rem;
-  border-radius: 0.5rem;
-  box-shadow: 0 0 12px rgba(0, 0, 0, 0.35);
-}
-
-.players {
-  width: min(960px, 95vw);
-  display: grid;
-  grid-template-areas:
-    "top top top"
-    "left center right"
-    "bottom bottom bottom";
-  gap: 1rem;
-}
-
-.player {
-  background: rgba(11, 56, 42, 0.85);
-  border-radius: 0.75rem;
-  padding: 0.75rem;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08), 0 12px 24px rgba(0, 0, 0, 0.25);
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.player h2 {
-  margin: 0;
-  font-size: 1rem;
-}
-
-.player-top {
-  grid-area: top;
-}
-
-.player-left {
-  grid-area: left;
-}
-
-.player-right {
-  grid-area: right;
-}
-
-.player-bottom {
-  grid-area: bottom;
-}
-
-.center-controls {
-  grid-area: center;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0.75rem;
-  padding: 1rem;
-  background: rgba(7, 38, 30, 0.7);
-  border-radius: 0.75rem;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
-}
-
-.center-controls button {
-  min-width: 140px;
-  padding: 0.5rem 1rem;
-  border-radius: 999px;
-  border: none;
-  background: linear-gradient(135deg, #3ac78f, #22865e);
-  color: #fff;
-  font-size: 1rem;
-  font-weight: bold;
-  cursor: pointer;
-  transition: transform 0.1s ease, box-shadow 0.1s ease;
-}
-
-.center-controls button:disabled {
-  cursor: not-allowed;
-  background: #3a4a5d;
-  color: #c9d5e2;
-}
-
-.center-controls button:not(:disabled):hover {
-  transform: translateY(-1px);
-  box-shadow: 0 6px 16px rgba(49, 163, 112, 0.45);
-}
-
-.center-controls .hint {
-  margin: 0;
-  font-size: 0.85rem;
-  color: #b5c9dd;
   text-align: center;
+  color: var(--muted-color);
+  font-size: 0.85rem;
 }
 
-.hand,
-.river {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  min-height: 40px;
-}
-
-.tile {
-  padding: 0.35rem 0.6rem;
-  border-radius: 0.5rem;
-  background: rgba(255, 255, 255, 0.15);
-  border: 1px solid rgba(255, 255, 255, 0.25);
-  color: inherit;
-  font-size: 0.95rem;
-  font-weight: 600;
-  cursor: default;
-  transition: transform 0.1s ease, background 0.2s ease;
-}
-
-.player-bottom .tile {
-  cursor: pointer;
-}
-
-.player-bottom .tile:hover {
-  transform: translateY(-3px);
-  background: rgba(255, 255, 255, 0.3);
-}
-
-.player-bottom .tile:disabled {
-  cursor: not-allowed;
-  opacity: 0.7;
-  transform: none;
-}
-
-.log-panel {
-  width: min(960px, 95vw);
-  background: rgba(7, 38, 30, 0.7);
-  border-radius: 0.75rem;
-  padding: 0.75rem 1rem 1rem;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05), 0 10px 18px rgba(0, 0, 0, 0.25);
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.log-panel h2 {
-  margin: 0;
-  font-size: 1rem;
-  color: #bfe8cd;
-}
-
-.log-list {
-  list-style: decimal;
-  padding-left: 1.2rem;
-  margin: 0;
-  max-height: 180px;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  color: #e6f5ec;
-}
-
-.log-list li {
-  background: rgba(22, 78, 61, 0.55);
-  border-radius: 0.5rem;
-  padding: 0.35rem 0.5rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  font-size: 0.9rem;
-}
-
-@media (max-width: 768px) {
-  .players {
-    grid-template-areas:
-      "top"
-      "center"
-      "left"
-      "right"
-      "bottom";
+@media (max-width: 1024px) {
+  .game-container {
+    grid-template-columns: 1fr;
   }
 
-  .player {
-    align-items: center;
+  .hud,
+  .help {
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-between;
   }
 
-  .hand,
-  .river {
-    justify-content: center;
+  .hud {
+    gap: 12px;
+  }
+
+  .hud-panel {
+    flex: 1 1 120px;
+  }
+
+  .hud-panel--next {
+    align-items: flex-start;
+  }
+
+  .help {
+    gap: 8px 16px;
+  }
+
+  .help dl {
+    width: 100%;
+  }
+
+  .playfield {
+    order: -1;
+  }
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 16px;
+  }
+
+  .playfield {
+    padding: 16px;
+  }
+
+  #board {
+    width: 240px;
+    height: 480px;
   }
 }


### PR DESCRIPTION
## Summary
- replace the experimental Mahjong UI with a standalone browser Tetris experience
- implement falling piece logic, rotation with wall kicks, scoring, level progression, and next-piece preview in vanilla JS
- refresh the layout and documentation to explain controls and web gameplay

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_6905c6b747188321a9525eee6ddba417